### PR TITLE
Update CRL versions to match RFC 5280.

### DIFF
--- a/crlbuilder/__init__.py
+++ b/crlbuilder/__init__.py
@@ -640,7 +640,7 @@ class CertificateListBuilder(object):
             })
 
         tbs_cert_list = crl.TbsCertList({
-            'version': 'v3',
+            'version': 'v2',
             'signature': {
                 'algorithm': signature_algorithm_id
             },

--- a/tests/test_certificate_list_builder.py
+++ b/tests/test_certificate_list_builder.py
@@ -41,7 +41,7 @@ class CertificateListBuilderTests(unittest.TestCase):
 
         now = datetime.now(timezone.utc)
 
-        self.assertEqual('v3', tbs_cert_list['version'].native)
+        self.assertEqual('v2', tbs_cert_list['version'].native)
         self.assertEqual('rsassa_pkcs1v15', tbs_cert_list['signature'].signature_algo)
         self.assertEqual('sha256', tbs_cert_list['signature'].hash_algo)
         self.assertEqual(root_certificate.asn1.subject, tbs_cert_list['issuer'])
@@ -109,7 +109,7 @@ class CertificateListBuilderTests(unittest.TestCase):
 
         now = datetime.now(timezone.utc)
 
-        self.assertEqual('v3', tbs_cert_list['version'].native)
+        self.assertEqual('v2', tbs_cert_list['version'].native)
         self.assertEqual('rsassa_pkcs1v15', tbs_cert_list['signature'].signature_algo)
         self.assertEqual('sha256', tbs_cert_list['signature'].hash_algo)
         self.assertEqual(crl_issuer_certificate.asn1.subject, tbs_cert_list['issuer'])
@@ -182,7 +182,7 @@ class CertificateListBuilderTests(unittest.TestCase):
 
         now = datetime.now(timezone.utc)
 
-        self.assertEqual('v3', tbs_cert_list['version'].native)
+        self.assertEqual('v2', tbs_cert_list['version'].native)
         self.assertEqual('rsassa_pkcs1v15', tbs_cert_list['signature'].signature_algo)
         self.assertEqual('sha256', tbs_cert_list['signature'].hash_algo)
         self.assertEqual(crl_issuer_certificate.asn1.subject, tbs_cert_list['issuer'])


### PR DESCRIPTION
Update CRL versions to match RFC 5280.

See https://datatracker.ietf.org/doc/html/rfc5280#section-5.1.2.1